### PR TITLE
Add simple job queue with tracing

### DIFF
--- a/polars-query-server/src/api.rs
+++ b/polars-query-server/src/api.rs
@@ -1,25 +1,36 @@
-use axum::{response::IntoResponse, routing::post, Json, Router};
+use axum::{extract::State, response::IntoResponse, routing::post, Json, Router};
 use serde_json::json;
 use tower_http::cors::CorsLayer;
 use tracing::info;
+use std::sync::Arc;
+
+use crate::scheduler::Scheduler;
+
+#[derive(Clone)]
+pub struct AppState {
+    scheduler: Scheduler,
+}
 
 /// Handler for `/run-query` which logs the incoming body and
 /// returns a simple JSON status response.
-async fn run_query(body: String) -> impl IntoResponse {
+async fn run_query(State(state): State<Arc<AppState>>, body: String) -> impl IntoResponse {
     info!(%body, "received query");
-    Json(json!({ "status": "received" }))
+    let (job_id, status) = state.scheduler.enqueue(body).await;
+    Json(json!({ "job_id": job_id, "status": status, "output": null }))
 }
 
 /// Build the application router with CORS support.
-pub fn app() -> Router {
+pub fn app(state: AppState) -> Router {
     Router::new()
         .route("/run-query", post(run_query))
         .layer(CorsLayer::permissive())
+        .with_state(Arc::new(state))
 }
 
 /// Start the HTTP server on `127.0.0.1:3000`.
 pub async fn start_server() {
-    let app = app();
+    let scheduler = Scheduler::new();
+    let app = app(AppState { scheduler });
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], 3000));
     tracing::info!("listening on {}", addr);
     axum::Server::bind(&addr)

--- a/polars-query-server/src/scheduler.rs
+++ b/polars-query-server/src/scheduler.rs
@@ -1,4 +1,85 @@
-pub fn schedule_job(job: &str) {
-    // TODO: schedule job execution
-    println!("Scheduling job: {}", job);
+use std::collections::VecDeque;
+use std::sync::{Arc, atomic::{AtomicU64, AtomicUsize, Ordering}};
+
+use tokio::sync::mpsc;
+use tokio::time::Instant;
+use tracing::info;
+
+use crate::executor;
+
+/// A job submitted to the scheduler.
+struct Job {
+    id: u64,
+    query: String,
+}
+
+/// Scheduler managing job execution with a maximum number of concurrent jobs.
+#[derive(Clone)]
+pub struct Scheduler {
+    tx: mpsc::Sender<Job>,
+    active: Arc<AtomicUsize>,
+    next_id: Arc<AtomicU64>,
+}
+
+impl Scheduler {
+    /// Create a new scheduler and spawn the background worker.
+    pub fn new() -> Self {
+        let (tx, mut rx) = mpsc::channel::<Job>(100);
+        let (complete_tx, mut complete_rx) = mpsc::channel::<()>(100);
+        let active = Arc::new(AtomicUsize::new(0));
+        let next_id = Arc::new(AtomicU64::new(1));
+        let active_bg = active.clone();
+
+        tokio::spawn(async move {
+            let mut queue: VecDeque<Job> = VecDeque::new();
+            loop {
+                tokio::select! {
+                    Some(job) = rx.recv() => {
+                        if active_bg.load(Ordering::SeqCst) < 4 {
+                            spawn_job(job, complete_tx.clone(), active_bg.clone());
+                        } else {
+                            queue.push_back(job);
+                        }
+                    }
+                    Some(_) = complete_rx.recv() => {
+                        active_bg.fetch_sub(1, Ordering::SeqCst);
+                        if let Some(job) = queue.pop_front() {
+                            spawn_job(job, complete_tx.clone(), active_bg.clone());
+                        }
+                    }
+                    else => break,
+                }
+            }
+        });
+
+        Scheduler { tx, active, next_id }
+    }
+
+    /// Enqueue a new job and return its id and whether it starts immediately or
+    /// is queued.
+    pub async fn enqueue(&self, query: String) -> (u64, &'static str) {
+        let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+        let status = if self.active.load(Ordering::SeqCst) < 4 {
+            "running"
+        } else {
+            "queued"
+        };
+        let job = Job { id, query };
+        // Ignore send errors - only possible if scheduler loop has shut down.
+        let _ = self.tx.send(job).await;
+        (id, status)
+    }
+}
+
+/// Spawn a task to execute a job and notify when complete.
+fn spawn_job(job: Job, complete: mpsc::Sender<()>, active: Arc<AtomicUsize>) {
+    active.fetch_add(1, Ordering::SeqCst);
+    tokio::spawn(async move {
+        let start = Instant::now();
+        info!(job_id = job.id, "job started");
+        executor::execute_plan(&job.query);
+        let duration = start.elapsed();
+        info!(job_id = job.id, ?duration, "job finished");
+        let _ = complete.send(()).await;
+    });
 }


### PR DESCRIPTION
## Summary
- implement `Scheduler` to queue and run jobs with a 4-task limit
- track job start/end with `tracing`
- expose `AppState` in API and enqueue queries

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6872cfcff468832083cdf728b184d988