### PR TITLE
Improve README and add coverage workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,29 @@
+name: Rust CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Build
+        run: cargo build --workspace --all-targets
+      - name: Test
+        run: cargo test --workspace --all-targets
+      - name: Install tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Coverage
+        run: |
+          cargo tarpaulin --workspace --timeout 120 --out Xml > coverage.log
+          grep "line coverage" coverage.log | tee coverage_summary.txt
+          cat coverage_summary.txt >> $GITHUB_STEP_SUMMARY
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-log
+          path: coverage.log

--- a/README.md
+++ b/README.md
@@ -1,2 +1,82 @@
 # rdata
-Execute Polars on rust
+
+`rdata` contains **polars-query-server**, a minimal HTTP service written in Rust for executing [Polars](https://pola.rs/) queries. The server accepts textual query plans and returns the resulting data either inline (compressed) or as a Feather file on disk.
+
+## Running the Server
+
+```bash
+cd polars-query-server
+cargo run
+```
+
+The server listens on `127.0.0.1:3000` and exposes a single `POST /run-query` endpoint.
+
+### Example Query
+
+Save the following to `query.txt`:
+
+```text
+df = pl.read_parquet("data/sample_0.parquet")
+df = df.filter(pl.col("age") > 30)
+df = df.groupby("city").agg(pl.col("balance").mean())
+```
+
+Send it using `curl`:
+
+```bash
+curl -X POST http://127.0.0.1:3000/run-query -d @query.txt
+```
+
+A Python example using `httpx`:
+
+```python
+import httpx
+query = """
+df = pl.read_parquet('data/sample_0.parquet')
+df = df.select(['name','age'])
+"""
+resp = httpx.post('http://127.0.0.1:3000/run-query', content=query)
+print(resp.json())
+```
+
+## Generating Sample Data
+
+Large Parquet files for testing can be generated with:
+
+```bash
+cd polars-query-server/data_gen
+python3 generate_parquet_data.py
+```
+
+Files are created under `polars-query-server/data/`.
+
+## Load Testing
+
+Once the server is running and data is generated you can execute a simple load test:
+
+```bash
+cd polars-query-server/load_test
+python3 run_load_test.py
+```
+
+A CSV summary will be written to `load_test_summary.csv`.
+
+## Running the Tests
+
+All unit and integration tests can be executed with:
+
+```bash
+cd polars-query-server
+cargo test
+```
+
+### Code Coverage
+
+The project uses [cargo-tarpaulin](https://github.com/xd009642/tarpaulin) for coverage. Install it once and run:
+
+```bash
+cargo install cargo-tarpaulin
+cargo tarpaulin --workspace --timeout 120
+```
+
+The coverage percentage will be printed at the end of the run and is also reported in the CI workflow summary.

--- a/polars-query-server/src/utils.rs
+++ b/polars-query-server/src/utils.rs
@@ -44,3 +44,29 @@ pub fn prepare_output(id: u64, df: &DataFrame) -> io::Result<PreparedOutput> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn small_dataframe_inline() {
+        let mut df = df!["val" => [1, 2, 3]].unwrap();
+        let out = prepare_output(1, &df).unwrap();
+        assert!(out.bytes.is_some());
+        assert!(out.path.is_none());
+    }
+
+    #[test]
+    fn large_dataframe_as_file() {
+        let data: Vec<i32> = (0..1_000_000).collect();
+        let df = df!["val" => &data].unwrap();
+        let out = prepare_output(2, &df).unwrap();
+        assert!(out.bytes.is_none());
+        assert!(out.path.is_some());
+        let path = out.path.unwrap();
+        assert!(fs::metadata(&path).is_ok());
+        fs::remove_file(path).unwrap();
+    }
+}


### PR DESCRIPTION
## Summary
- document how to run server and tests
- show example service calls
- add instructions for generating data and running load tests
- add GitHub Actions workflow with code coverage
- add unit tests for utils::prepare_output

## Testing
- `cargo test --all-targets --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6872d9e620b883208cfd01f1e860a09d