### PR TITLE
Improve coverage and summary reporting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,9 +22,16 @@ jobs:
         run: cargo install cargo-tarpaulin
       - name: Coverage
         run: |
-          cargo tarpaulin --workspace --timeout 120 --out Xml > coverage.log
-          grep "line coverage" coverage.log | tee coverage_summary.txt
-          cat coverage_summary.txt >> $GITHUB_STEP_SUMMARY
+          cargo tarpaulin --workspace --timeout 120 --out Json --output-dir . > coverage.log
+          jq -r '.files[] | "\(.path | join("/")) \(.covered) \(.coverable)"' tarpaulin-report.json > coverage_raw.txt
+          echo "| File | Coverage |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+          awk '{ pct=($2/$3)*100; printf "| %s | %.2f%% |\n", $1, pct }' coverage_raw.txt >> $GITHUB_STEP_SUMMARY
+      - name: Build Docker image
+        run: |
+          docker build -t polars-query-server:latest .
+          ID=$(docker images --no-trunc --quiet polars-query-server:latest)
+          echo "| Docker Image | $ID |" >> $GITHUB_STEP_SUMMARY
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/polars-query-server/src/utils.rs
+++ b/polars-query-server/src/utils.rs
@@ -60,7 +60,7 @@ mod tests {
 
     #[test]
     fn large_dataframe_as_file() {
-        let data: Vec<i32> = (0..1_000_000).collect();
+        let data: Vec<i32> = (0..5_000_000).collect();
         let df = df!["val" => &data].unwrap();
         let out = prepare_output(2, &df).unwrap();
         assert!(out.bytes.is_none());

--- a/polars-query-server/tests/integration.rs
+++ b/polars-query-server/tests/integration.rs
@@ -37,3 +37,28 @@ async fn post_query_returns_data() {
     assert!(v.get("job_id").is_some());
     assert!(v.get("output").is_some());
 }
+
+#[tokio::test]
+async fn post_query_large_output_file() {
+    let scheduler = Scheduler::new();
+    let app = app(AppState { scheduler });
+
+    let data: Vec<i32> = (0..1_000_000).collect();
+    let mut df = df!["val" => &data].unwrap();
+    let file = NamedTempFile::new().unwrap();
+    ParquetWriter::new(File::create(file.path()).unwrap())
+        .finish(&mut df)
+        .unwrap();
+
+    let query = format!("df = pl.read_parquet(\"{}\")", file.path().display());
+    let response = app
+        .oneshot(Request::post("/run-query").body(Body::from(query)).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let path = v.get("output").and_then(|o| o.as_str()).unwrap();
+    assert!(std::path::Path::new(path).exists());
+    std::fs::remove_file(path).unwrap();
+}


### PR DESCRIPTION
## Summary
- add coverage table and docker image info to workflow
- expand parser tests to cover more operations
- add executor tests for filter and aggregation parsing
- test scheduler cost estimates and job metrics
- record query metrics using an isolated temp dir
- enlarge utils file output test
- add integration test for large query results

## Testing
- `cargo test --release -j 1 --quiet` *(failed: OOM during linking)*

------
https://chatgpt.com/codex/tasks/task_e_6873911f54e48320806fd5c1d125f039